### PR TITLE
Improve CMake macOS build

### DIFF
--- a/AerofoilX/GpMain_SDL_X.cpp
+++ b/AerofoilX/GpMain_SDL_X.cpp
@@ -20,7 +20,9 @@
 #include "IGpVOSEventQueue.h"
 
 #include <string>
+#ifdef __MACOS__
 #include "MacInit.h"
+#endif
 
 GpXGlobals g_gpXGlobals;
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(PortabilityLayer STATIC
 	PortabilityLayer/BitmapImage.cpp
 	PortabilityLayer/ByteSwap.cpp
 	PortabilityLayer/CFileStream.cpp
+	PortabilityLayer/CompositeRenderedFont.cpp
 	PortabilityLayer/DeflateCodec.cpp
 	PortabilityLayer/DialogManager.cpp
 	PortabilityLayer/DisplayDeviceManager.cpp
@@ -240,7 +241,8 @@ target_include_directories(GpApp PRIVATE
 target_link_libraries(GpApp PortabilityLayer)
 
 if(CMAKE_HOST_UNIX)
-	add_executable(${EXECNAME}
+	set(EXEC_SOURCES )
+	list(APPEND EXEC_SOURCES
 		AerofoilPortable/GpSystemServices_POSIX.cpp
 		AerofoilPortable/GpThreadEvent_Cpp11.cpp
 		AerofoilPortable/GpAllocator_C.cpp
@@ -257,8 +259,16 @@ if(CMAKE_HOST_UNIX)
 		AerofoilX/GpSystemServices_X.cpp
 		AerofoilX/GpFileSystem_X.cpp
 		)
-		
-	target_include_directories(${EXECNAME} PRIVATE
+
+	set(EXEC_LIBS )
+	list(APPEND EXEC_LIBS
+		${SDL2_LIBRARIES}
+		GpApp
+		GpShell
+		)
+
+	set(EXEC_INC_DIRS )
+	list(APPEND EXEC_INC_DIRS
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common>
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GpCommon>
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GpShell>
@@ -267,8 +277,22 @@ if(CMAKE_HOST_UNIX)
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/PortabilityLayer>
 		${SDL2_INCLUDE_DIRS}
 		)
+	if(PLATFORM STREQUAL "MAC")
+		list(APPEND EXEC_SOURCES
+			AerofoilMac/AerofoilMac/AerofoilApplication.mm
+			AerofoilMac/AerofoilMac/MacInit.mm
+			)
+		list(APPEND EXEC_INC_DIRS
+			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/AerofoilMac/AerofoilMac>
+			)
+		list(APPEND EXEC_LIBS
+			"-framework Cocoa"
+			)
+	endif(PLATFORM STREQUAL "MAC")
 
-	target_link_libraries(${EXECNAME} ${SDL2_LIBRARIES} GpApp GpShell)
+	add_executable(${EXECNAME} ${EXEC_SOURCES})
+	target_include_directories(${EXECNAME} PRIVATE ${EXEC_INC_DIRS})
+	target_link_libraries(${EXECNAME} ${EXEC_LIBS})
 endif()
 
 


### PR DESCRIPTION
Now actually builds on macOS (provided you use `cmake -DPLATFORM=MAC` and d470bb5eebcf3a18ede7f3eb106563a0220deb14 is reverted).

Closes #9

`make install` still needs to be improved. It currently just copies the executable into $prefix/bin which is not how Mac applications are packaged, and of course it doesn't copy the data files without which the app won't run. But if the built executable is put into a manually-created app bundle along with the data from the Windows version it works fine.