### PR TITLE
Include stdlib.h where its functions are used

### DIFF
--- a/AerofoilPortable/GpThreadEvent_Cpp11.cpp
+++ b/AerofoilPortable/GpThreadEvent_Cpp11.cpp
@@ -1,5 +1,7 @@
 #include "GpThreadEvent_Cpp11.h"
 
+#include <stdlib.h>
+
 GpThreadEvent_Cpp11::GpThreadEvent_Cpp11(bool autoReset, bool startSignaled)
 	: m_flag(startSignaled)
 	, m_autoReset(autoReset)

--- a/AerofoilX/GpLogDriver_X.cpp
+++ b/AerofoilX/GpLogDriver_X.cpp
@@ -4,6 +4,7 @@
 #include "GpApplicationName.h"
 #include "GpIOStream.h"
 
+#include <stdlib.h>
 #include <time.h>
 #include <cstring>
 

--- a/PortabilityLayer/ZipFileProxy.cpp
+++ b/PortabilityLayer/ZipFileProxy.cpp
@@ -10,6 +10,7 @@
 #include "DeflateCodec.h"
 
 #include <algorithm>
+#include <stdlib.h>
 
 namespace
 {


### PR DESCRIPTION
Fixes build failure on OS X 10.10 and 10.11:

```
error: use of undeclared identifier 'free'
error: use of undeclared identifier 'malloc'
error: use of undeclared identifier 'qsort'
```