### PR TITLE
Improve CMake build and port conversion tools to Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,5 +373,19 @@ target_include_directories(FTagData PRIVATE
 	)
 target_link_libraries(FTagData PortabilityLayer)
 
+add_executable(MergeGPF
+	MergeGPF/MergeGPF.cpp
+	AerofoilPortable/GpAllocator_C.cpp
+	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+	)
+target_include_directories(MergeGPF PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	AerofoilPortable
+	WindowsUnicodeToolShim
+	)
+target_link_libraries(MergeGPF PortabilityLayer)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,4 +489,43 @@ target_include_directories(ConvertColorCursors PRIVATE
 target_link_libraries(ConvertColorCursors PortabilityLayer)
 
 
-install (TARGETS ${EXECNAME})
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaged/Houses")
+
+set(DATA_FILES)
+
+list(APPEND DATA_FILES Packaged/ApplicationResources.gpf)
+add_custom_command(
+	OUTPUT
+		Packaged/ApplicationResources.gpf
+	BYPRODUCTS
+		Packaged/ApplicationResources.gpr
+		Packaged/ApplicationResources.gpa
+	DEPENDS MiniRez gpr2gpa FTagData MergeGPF
+	COMMAND MiniRez
+		"GliderProData/Glider PRO.r"
+		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpr"
+	COMMAND gpr2gpa
+		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpr"
+		DefaultTimestamp.timestamp
+		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpa"
+		-patch ApplicationResourcePatches/manifest.json
+	COMMAND FTagData
+		DefaultTimestamp.timestamp
+		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpf"
+		data ozm5 0 0 locked
+	COMMAND MergeGPF
+		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpf"
+	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+	VERBATIM
+	)
+
+add_custom_target(Resources ALL
+	DEPENDS
+		${DATA_FILES}
+	)
+
+
+list(TRANSFORM DATA_FILES PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
+
+install(TARGETS "${EXECNAME}" COMPONENT Executable)
+install(FILES ${DATA_FILES} DESTINATION lib/aerofoil/Packaged COMPONENT Resources)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,13 +493,36 @@ file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaged/Houses")
 
 set(DATA_FILES)
 
-list(APPEND DATA_FILES Packaged/ApplicationResources.gpf)
-add_custom_command(
-	OUTPUT
-		Packaged/ApplicationResources.gpf
+function(add_data_file NAME)
+	list(APPEND DATA_FILES "Packaged/${NAME}")
+	set(DATA_FILES "${DATA_FILES}" PARENT_SCOPE)
+
+	cmake_parse_arguments(PARSE_ARGV 1 ARG
+		""
+		""
+		"BYPRODUCTS;COMMANDS"
+		)
+
+	if(ARG_BYPRODUCTS)
+		set(RM_BYPRODUCTS_COMMAND COMMAND "${CMAKE_COMMAND}" -E rm)
+		set(RM_BYPRODUCTS_PATHS "${ARG_BYPRODUCTS}")
+		list(TRANSFORM RM_BYPRODUCTS_PATHS PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
+	endif()
+
+	add_custom_command(
+		OUTPUT "Packaged/${NAME}"
+		BYPRODUCTS ${ARG_BYPRODUCTS}
+		${ARG_COMMANDS}
+		${RM_BYPRODUCTS_COMMAND} ${RM_BYPRODUCTS_PATHS}
+		VERBATIM
+		)
+endfunction()
+
+add_data_file(ApplicationResources.gpf
 	BYPRODUCTS
 		Packaged/ApplicationResources.gpr
 		Packaged/ApplicationResources.gpa
+	COMMANDS
 	DEPENDS MiniRez gpr2gpa FTagData MergeGPF
 	COMMAND MiniRez
 		"GliderProData/Glider PRO.r"
@@ -516,13 +539,9 @@ add_custom_command(
 	COMMAND MergeGPF
 		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpf"
 	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-	VERBATIM
 	)
 
-list(APPEND DATA_FILES Packaged/Fonts.gpf)
-add_custom_command(
-	OUTPUT
-		Packaged/Fonts.gpf
+add_data_file(Fonts.gpf
 	BYPRODUCTS
 		Packaged/Fonts.gpr
 		Packaged/Fonts.gpa
@@ -543,6 +562,7 @@ add_custom_command(
 		Packaged/CachedFont12.bin
 		Packaged/CachedFont13.bin
 		Packaged/CachedFont14.bin
+	COMMANDS
 	DEPENDS GenerateFonts MiniRez gpr2gpa FTagData MergeGPF
 	COMMAND GenerateFonts "${CMAKE_SOURCE_DIR}/Resources" Packaged
 	COMMAND MiniRez "${CMAKE_SOURCE_DIR}/Empty.r" Packaged/Fonts.gpr
@@ -556,7 +576,6 @@ add_custom_command(
 		Packaged/Fonts.gpf
 		data ozm5 0 0 locked
 	COMMAND MergeGPF Packaged/Fonts.gpf
-	VERBATIM
 	)
 
 # These files are committed to the repo and aren't currently useful on non-Windows systems anyway.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,5 +387,14 @@ target_include_directories(MergeGPF PRIVATE
 	)
 target_link_libraries(MergeGPF PortabilityLayer)
 
+add_executable(MiniRez MiniRez/MiniRez.cpp WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp)
+target_include_directories(MiniRez PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	WindowsUnicodeToolShim
+	)
+target_link_libraries(MiniRez PortabilityLayer)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,7 +511,11 @@ target_include_directories(ConvertColorCursors PRIVATE
 target_link_libraries(ConvertColorCursors PortabilityLayer)
 
 
-file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaged/Houses")
+add_custom_target(BuildDirs
+	BYPRODUCTS Packaged
+	COMMAND "${CMAKE_COMMAND}" -E make_directory Packaged/Houses
+	VERBATIM
+	)
 
 set(DATA_FILES)
 
@@ -534,6 +538,7 @@ function(add_data_file NAME)
 	add_custom_command(
 		OUTPUT "Packaged/${NAME}"
 		BYPRODUCTS ${ARG_BYPRODUCTS}
+		DEPENDS BuildDirs
 		${ARG_COMMANDS}
 		${RM_BYPRODUCTS_COMMAND} ${RM_BYPRODUCTS_PATHS}
 		VERBATIM
@@ -646,7 +651,7 @@ function(add_house NAME)
 			"${BASE_PATH}.gpf"
 		BYPRODUCTS
 			${BYPRODUCTS}
-		DEPENDS hqx2gp gpr2gpa MergeGPF
+		DEPENDS hqx2gp gpr2gpa MergeGPF BuildDirs
 		COMMAND hqx2gp
 			"${CMAKE_SOURCE_DIR}/GliderProData/Houses/${NAME}.binhex"
 			"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
@@ -673,7 +678,7 @@ function(add_house NAME)
 				"${BASE_PATH}.mov.gpf"
 			BYPRODUCTS
 				"${BASE_PATH}.mov.gpa"
-			DEPENDS FTagData MergeGPF "${MOV_GPA_SRC}"
+			DEPENDS FTagData MergeGPF BuildDirs "${MOV_GPA_SRC}"
 			COMMAND FTagData
 				"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
 				"${BASE_PATH}.mov.gpf"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,5 +472,21 @@ if(FREETYPE_FOUND)
 	target_link_libraries(GenerateFonts PortabilityLayer GpFontHandler_FreeType2)
 endif()
 
+add_executable(ConvertColorCursors
+	ConvertColorCursors/ConvertColorCursors.cpp
+	AerofoilPortable/GpAllocator_C.cpp
+	stb/stb_image_write.c
+	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+	)
+target_include_directories(ConvertColorCursors PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	AerofoilPortable
+	stb
+	WindowsUnicodeToolShim
+	)
+target_link_libraries(ConvertColorCursors PortabilityLayer)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,5 +359,9 @@ target_include_directories(gpr2gpa PRIVATE
 	)
 target_link_libraries(gpr2gpa PortabilityLayer MacRomanConversion zlib)
 
+add_executable(MakeTimestamp MakeTimestamp/MakeTimestamp.cpp)
+target_include_directories(MakeTimestamp PRIVATE PortabilityLayer)
+target_link_libraries(MakeTimestamp PortabilityLayer)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,21 @@ if(FREETYPE_FOUND)
 		)
 
 	target_link_libraries(GpFontHandler_FreeType2 PRIVATE Freetype::Freetype)
+
+
+	add_executable(GenerateFonts
+		GenerateFonts/GenerateFonts.cpp
+		AerofoilPortable/GpAllocator_C.cpp
+		WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+		)
+	target_include_directories(GenerateFonts PRIVATE
+		Common
+		GpCommon
+		PortabilityLayer
+		AerofoilPortable
+		WindowsUnicodeToolShim
+		)
+	target_link_libraries(GenerateFonts PortabilityLayer GpFontHandler_FreeType2)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ if(CMAKE_HOST_UNIX)
 endif()
 
 
-add_executable(flattenmov flattenmov/flattenmov.cpp AerofoilPortable/GpAllocator_C.cpp)
+add_executable(flattenmov EXCLUDE_FROM_ALL flattenmov/flattenmov.cpp AerofoilPortable/GpAllocator_C.cpp)
 target_include_directories(flattenmov PRIVATE
 	Common
 	GpCommon
@@ -325,7 +325,7 @@ target_include_directories(flattenmov PRIVATE
 	)
 target_link_libraries(flattenmov PortabilityLayer)
 
-add_executable(bin2gp bin2gp/bin2gp.cpp AerofoilPortable/GpAllocator_C.cpp)
+add_executable(bin2gp EXCLUDE_FROM_ALL bin2gp/bin2gp.cpp AerofoilPortable/GpAllocator_C.cpp)
 target_include_directories(bin2gp PRIVATE
 	Common
 	GpCommon
@@ -334,7 +334,7 @@ target_include_directories(bin2gp PRIVATE
 	)
 target_link_libraries(bin2gp PortabilityLayer)
 
-add_executable(hqx2bin hqx2bin/hqx2bin.cpp AerofoilPortable/GpAllocator_C.cpp)
+add_executable(hqx2bin EXCLUDE_FROM_ALL hqx2bin/hqx2bin.cpp AerofoilPortable/GpAllocator_C.cpp)
 target_include_directories(hqx2bin PRIVATE
 	Common
 	GpCommon
@@ -343,7 +343,7 @@ target_include_directories(hqx2bin PRIVATE
 	)
 target_link_libraries(hqx2bin PortabilityLayer)
 
-add_executable(hqx2gp
+add_executable(hqx2gp EXCLUDE_FROM_ALL
 	hqx2gp/hqx2gp.cpp
 	AerofoilPortable/GpAllocator_C.cpp
 	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
@@ -357,7 +357,7 @@ target_include_directories(hqx2gp PRIVATE
 	)
 target_link_libraries(hqx2gp PortabilityLayer)
 
-add_executable(gpr2gpa
+add_executable(gpr2gpa EXCLUDE_FROM_ALL
 	gpr2gpa/gpr2gpa.cpp
 	gpr2gpa/macedec.cpp
 	AerofoilPortable/GpAllocator_C.cpp
@@ -375,11 +375,14 @@ target_include_directories(gpr2gpa PRIVATE
 	)
 target_link_libraries(gpr2gpa PortabilityLayer MacRomanConversion zlib)
 
-add_executable(MakeTimestamp MakeTimestamp/MakeTimestamp.cpp)
+add_executable(MakeTimestamp EXCLUDE_FROM_ALL MakeTimestamp/MakeTimestamp.cpp)
 target_include_directories(MakeTimestamp PRIVATE PortabilityLayer)
 target_link_libraries(MakeTimestamp PortabilityLayer)
 
-add_executable(FTagData FTagData/FTagData.cpp WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp)
+add_executable(FTagData EXCLUDE_FROM_ALL
+	FTagData/FTagData.cpp
+	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+	)
 target_include_directories(FTagData PRIVATE
 	Common
 	GpCommon
@@ -389,7 +392,7 @@ target_include_directories(FTagData PRIVATE
 	)
 target_link_libraries(FTagData PortabilityLayer)
 
-add_executable(MergeGPF
+add_executable(MergeGPF EXCLUDE_FROM_ALL
 	MergeGPF/MergeGPF.cpp
 	AerofoilPortable/GpAllocator_C.cpp
 	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
@@ -403,7 +406,7 @@ target_include_directories(MergeGPF PRIVATE
 	)
 target_link_libraries(MergeGPF PortabilityLayer)
 
-add_executable(MiniRez MiniRez/MiniRez.cpp WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp)
+add_executable(MiniRez EXCLUDE_FROM_ALL MiniRez/MiniRez.cpp WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp)
 target_include_directories(MiniRez PRIVATE
 	Common
 	GpCommon
@@ -412,7 +415,10 @@ target_include_directories(MiniRez PRIVATE
 	)
 target_link_libraries(MiniRez PortabilityLayer)
 
-add_executable(HouseTool HouseTool/HouseTool.cpp WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp)
+add_executable(HouseTool EXCLUDE_FROM_ALL
+	HouseTool/HouseTool.cpp
+	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+	)
 target_include_directories(HouseTool PRIVATE
 	Common
 	GpCommon
@@ -422,7 +428,7 @@ target_include_directories(HouseTool PRIVATE
 	)
 target_link_libraries(HouseTool PortabilityLayer MacRomanConversion)
 
-add_executable(unpacktool
+add_executable(unpacktool EXCLUDE_FROM_ALL
 	unpacktool/ArchiveDescription.cpp
 	unpacktool/BWT.cpp
 	unpacktool/CompactProLZHDecompressor.cpp
@@ -473,7 +479,7 @@ if(FREETYPE_FOUND)
 	target_link_libraries(GpFontHandler_FreeType2 PRIVATE Freetype::Freetype)
 
 
-	add_executable(GenerateFonts
+	add_executable(GenerateFonts EXCLUDE_FROM_ALL
 		GenerateFonts/GenerateFonts.cpp
 		AerofoilPortable/GpAllocator_C.cpp
 		WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
@@ -488,7 +494,7 @@ if(FREETYPE_FOUND)
 	target_link_libraries(GenerateFonts PortabilityLayer GpFontHandler_FreeType2)
 endif()
 
-add_executable(ConvertColorCursors
+add_executable(ConvertColorCursors EXCLUDE_FROM_ALL
 	ConvertColorCursors/ConvertColorCursors.cpp
 	AerofoilPortable/GpAllocator_C.cpp
 	stb/stb_image_write.c
@@ -722,6 +728,19 @@ add_custom_target(Resources ALL
 		${HOUSE_FILES}
 	)
 
+set(TOOL_EXES
+	flattenmov
+	bin2gp
+	hqx2bin
+	hqx2gp
+	MakeTimestamp
+	FTagData
+	gpr2gpa
+	unpacktool
+	MergeGPF
+	)
+add_custom_target(Tools ALL DEPENDS ${TOOL_EXES})
+
 
 list(TRANSFORM DATA_FILES PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
 list(TRANSFORM HOUSE_FILES PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
@@ -729,3 +748,4 @@ list(TRANSFORM HOUSE_FILES PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
 install(TARGETS "${EXECNAME}" COMPONENT Executable)
 install(FILES ${DATA_FILES} DESTINATION lib/aerofoil/Packaged COMPONENT Resources)
 install(FILES ${HOUSE_FILES} DESTINATION lib/aerofoil/Packaged/Houses COMPONENT Resources)
+install(TARGETS ${TOOL_EXES} DESTINATION lib/aerofoil/tools COMPONENT Tools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,6 +714,8 @@ add_house("Teddy World")
 add_house("The Asylum Pro")
 add_house("Titanic")
 
+add_custom_target(Executable DEPENDS "${EXECNAME}")
+
 add_custom_target(Resources ALL
 	DEPENDS
 		${DATA_FILES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ SET(EXECNAME "AerofoilX" CACHE STRING "Defines the exec name")
 
 message(${CMAKE_BINARY_DIR})
 
+# FIXME: Clang treats this as an error by default; fixing the source rather
+# than downgrading the error to a warning would be a better solution.
+add_compile_options(
+	$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-error=c++11-narrowing>
+	)
+
 find_package(SDL2 REQUIRED)
 
 if(PLATFORM STREQUAL "MAC")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,5 +396,15 @@ target_include_directories(MiniRez PRIVATE
 	)
 target_link_libraries(MiniRez PortabilityLayer)
 
+add_executable(HouseTool HouseTool/HouseTool.cpp WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp)
+target_include_directories(HouseTool PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	MacRomanConversion
+	WindowsUnicodeToolShim
+	)
+target_link_libraries(HouseTool PortabilityLayer MacRomanConversion)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,13 +582,113 @@ add_custom_command(
 #	)
 #add_custom_target(Icons DEPENDS ${CONVERTED_ICONS})
 
+set(HOUSE_FILES)
+
+function(add_house NAME)
+	cmake_parse_arguments(PARSE_ARGV 0 ARG
+		""
+		PATCH
+		""
+		)
+
+	if(ARG_PATCH)
+		set(PATCH_ARGS -patch "${CMAKE_SOURCE_DIR}/HousePatches/${ARG_PATCH}")
+	endif()
+
+	set(BASE_PATH "Packaged/Houses/${NAME}")
+	list(APPEND HOUSE_FILES "${BASE_PATH}.gpf")
+
+	set(BYPRODUCTS "${BASE_PATH}.gpr" "${BASE_PATH}.gpa" "${BASE_PATH}.gpd")
+
+	add_custom_command(
+		OUTPUT
+			"${BASE_PATH}.gpf"
+		BYPRODUCTS
+			${BYPRODUCTS}
+		DEPENDS hqx2gp gpr2gpa MergeGPF
+		COMMAND hqx2gp
+			"${CMAKE_SOURCE_DIR}/GliderProData/Houses/${NAME}.binhex"
+			"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
+			"${BASE_PATH}"
+		COMMAND gpr2gpa
+			"${BASE_PATH}.gpr"
+			"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
+			"${BASE_PATH}.gpa"
+			${PATCH_ARGS}
+		${HOUSE_EXTRA_COMMANDS}
+		COMMAND MergeGPF
+			"${BASE_PATH}.gpf"
+		COMMAND "${CMAKE_COMMAND}" -E rm
+			${BYPRODUCTS}
+		VERBATIM
+		)
+
+	set(MOV_GPA_SRC "${CMAKE_SOURCE_DIR}/GliderProData/ConvertedMovies/${NAME}.mov.gpa")
+	if(EXISTS "${MOV_GPA_SRC}")
+		list(APPEND HOUSE_FILES "${BASE_PATH}.mov.gpf")
+
+		add_custom_command(
+			OUTPUT
+				"${BASE_PATH}.mov.gpf"
+			BYPRODUCTS
+				"${BASE_PATH}.mov.gpa"
+			DEPENDS FTagData MergeGPF "${MOV_GPA_SRC}"
+			COMMAND FTagData
+				"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
+				"${BASE_PATH}.mov.gpf"
+				MooV ozm5 0 0 locked
+			COMMAND "${CMAKE_COMMAND}" -E copy
+				-t "Packaged/Houses"
+				"${MOV_GPA_SRC}"
+			COMMAND MergeGPF
+				"${BASE_PATH}.mov.gpf"
+			COMMAND "${CMAKE_COMMAND}" -E rm
+				"${BASE_PATH}.mov.gpa"
+			VERBATIM
+			)
+	endif()
+	set(HOUSE_FILES "${HOUSE_FILES}" PARENT_SCOPE)
+endfunction()
+
+add_house("Art Museum")
+add_house("California or Bust!")
+
+set(HOUSE_EXTRA_COMMANDS
+	DEPENDS HouseTool
+	COMMAND HouseTool
+		patch "Packaged/Houses/Castle o' the Air.gpd" .firstRoom 77
+	)
+add_house("Castle o' the Air")
+unset(HOUSE_EXTRA_COMMANDS)
+
+add_house("CD Demo House")
+add_house("Davis Station")
+add_house("Demo House")
+add_house("Fun House")
+add_house("Grand Prix" PATCH "GrandPrix.json")
+add_house("ImagineHouse PRO II" PATCH "ImagineHousePROII.json")
+add_house("In The Mirror" PATCH "InTheMirror.json")
+add_house("Land of Illusion")
+add_house("Leviathan" PATCH "Leviathan.json")
+add_house("Metropolis")
+add_house("Nemo's Market")
+add_house("Rainbow's End" PATCH "RainbowsEnd.json")
+add_house("Slumberland")
+add_house("SpacePods")
+add_house("Teddy World")
+add_house("The Asylum Pro")
+add_house("Titanic")
+
 add_custom_target(Resources ALL
 	DEPENDS
 		${DATA_FILES}
+		${HOUSE_FILES}
 	)
 
 
 list(TRANSFORM DATA_FILES PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
+list(TRANSFORM HOUSE_FILES PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
 
 install(TARGETS "${EXECNAME}" COMPONENT Executable)
 install(FILES ${DATA_FILES} DESTINATION lib/aerofoil/Packaged COMPONENT Resources)
+install(FILES ${HOUSE_FILES} DESTINATION lib/aerofoil/Packaged/Houses COMPONENT Resources)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,5 +335,23 @@ target_include_directories(hqx2gp PRIVATE
 	)
 target_link_libraries(hqx2gp PortabilityLayer)
 
+add_executable(gpr2gpa
+	gpr2gpa/gpr2gpa.cpp
+	gpr2gpa/macedec.cpp
+	AerofoilPortable/GpAllocator_C.cpp
+	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+	)
+target_include_directories(gpr2gpa PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	AerofoilPortable
+	MacRomanConversion
+	WindowsUnicodeToolShim
+	rapidjson/include
+	zlib
+	)
+target_link_libraries(gpr2gpa PortabilityLayer MacRomanConversion zlib)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,7 +550,9 @@ add_data_file(ApplicationResources.gpf
 		Packaged/ApplicationResources.gpr
 		Packaged/ApplicationResources.gpa
 	COMMANDS
-	DEPENDS MiniRez gpr2gpa FTagData MergeGPF
+	DEPENDS
+		MiniRez gpr2gpa FTagData MergeGPF "GliderProData/Glider PRO.r"
+		ApplicationResourcePatches/manifest.json DefaultTimestamp.timestamp
 	COMMAND MiniRez
 		"GliderProData/Glider PRO.r"
 		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpr"
@@ -568,6 +570,7 @@ add_data_file(ApplicationResources.gpf
 	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 	)
 
+file(GLOB_RECURSE FONT_DEPS RELATIVE "${CMAKE_SOURCE_DIR}" CONFIGURE_DEPENDS Resources/Fonts/*)
 add_data_file(Fonts.gpf
 	BYPRODUCTS
 		Packaged/Fonts.gpr
@@ -590,7 +593,7 @@ add_data_file(Fonts.gpf
 		Packaged/CachedFont13.bin
 		Packaged/CachedFont14.bin
 	COMMANDS
-	DEPENDS GenerateFonts MiniRez gpr2gpa FTagData MergeGPF
+	DEPENDS GenerateFonts MiniRez gpr2gpa FTagData MergeGPF ${FONT_DEPS}
 	COMMAND GenerateFonts "${CMAKE_SOURCE_DIR}/Resources" Packaged
 	COMMAND MiniRez "${CMAKE_SOURCE_DIR}/Empty.r" Packaged/Fonts.gpr
 	COMMAND gpr2gpa
@@ -645,20 +648,22 @@ function(add_house NAME)
 	list(APPEND HOUSE_FILES "${BASE_PATH}.gpf")
 
 	set(BYPRODUCTS "${BASE_PATH}.gpr" "${BASE_PATH}.gpa" "${BASE_PATH}.gpd")
+	set(BINHEX_SRC "${CMAKE_SOURCE_DIR}/GliderProData/Houses/${NAME}.binhex")
+	set(TS "${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp")
 
 	add_custom_command(
 		OUTPUT
 			"${BASE_PATH}.gpf"
 		BYPRODUCTS
 			${BYPRODUCTS}
-		DEPENDS hqx2gp gpr2gpa MergeGPF BuildDirs
+		DEPENDS hqx2gp gpr2gpa MergeGPF BuildDirs "${BINHEX_SRC}" "${TS}"
 		COMMAND hqx2gp
-			"${CMAKE_SOURCE_DIR}/GliderProData/Houses/${NAME}.binhex"
-			"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
+			"${BINHEX_SRC}"
+			"${TS}"
 			"${BASE_PATH}"
 		COMMAND gpr2gpa
 			"${BASE_PATH}.gpr"
-			"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
+			"${TS}"
 			"${BASE_PATH}.gpa"
 			${PATCH_ARGS}
 		${HOUSE_EXTRA_COMMANDS}
@@ -678,9 +683,9 @@ function(add_house NAME)
 				"${BASE_PATH}.mov.gpf"
 			BYPRODUCTS
 				"${BASE_PATH}.mov.gpa"
-			DEPENDS FTagData MergeGPF BuildDirs "${MOV_GPA_SRC}"
+			DEPENDS FTagData MergeGPF BuildDirs "${MOV_GPA_SRC}" "${TS}"
 			COMMAND FTagData
-				"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
+				"${TS}"
 				"${BASE_PATH}.mov.gpf"
 				MooV ozm5 0 0 locked
 			COMMAND "${CMAKE_COMMAND}" -E copy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,4 +442,20 @@ target_include_directories(unpacktool PRIVATE
 target_link_libraries(unpacktool PortabilityLayer MacRomanConversion)
 
 
+find_package(Freetype)
+if(FREETYPE_FOUND)
+	add_library(GpFontHandler_FreeType2 STATIC
+		GpFontHandler_FreeType2/GpFontHandler_FreeType2.cpp
+		)
+
+	target_include_directories(GpFontHandler_FreeType2 PRIVATE
+		Common
+		GpCommon
+		"${FREETYPE_INCLUDE_DIR_ft2build}"
+		)
+
+	target_link_libraries(GpFontHandler_FreeType2 PRIVATE Freetype::Freetype)
+endif()
+
+
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,5 +312,14 @@ target_include_directories(bin2gp PRIVATE
 	)
 target_link_libraries(bin2gp PortabilityLayer)
 
+add_executable(hqx2bin hqx2bin/hqx2bin.cpp AerofoilPortable/GpAllocator_C.cpp)
+target_include_directories(hqx2bin PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	AerofoilPortable
+	)
+target_link_libraries(hqx2bin PortabilityLayer)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,5 +303,14 @@ target_include_directories(flattenmov PRIVATE
 	)
 target_link_libraries(flattenmov PortabilityLayer)
 
+add_executable(bin2gp bin2gp/bin2gp.cpp AerofoilPortable/GpAllocator_C.cpp)
+target_include_directories(bin2gp PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	AerofoilPortable
+	)
+target_link_libraries(bin2gp PortabilityLayer)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,8 +512,8 @@ target_link_libraries(ConvertColorCursors PortabilityLayer)
 
 
 add_custom_target(BuildDirs
-	BYPRODUCTS Packaged
-	COMMAND "${CMAKE_COMMAND}" -E make_directory Packaged/Houses
+	BYPRODUCTS Packaged tmp
+	COMMAND "${CMAKE_COMMAND}" -E make_directory Packaged/Houses tmp
 	VERBATIM
 	)
 
@@ -523,89 +523,61 @@ function(add_data_file NAME)
 	list(APPEND DATA_FILES "Packaged/${NAME}")
 	set(DATA_FILES "${DATA_FILES}" PARENT_SCOPE)
 
-	cmake_parse_arguments(PARSE_ARGV 1 ARG
-		""
-		""
-		"BYPRODUCTS;COMMANDS"
+	cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" "")
+	set(TMPDIR "${CMAKE_CURRENT_BINARY_DIR}/tmp/${NAME}")
+	list(TRANSFORM ARG_UNPARSED_ARGUMENTS
+		REPLACE {TMPDIR} "${TMPDIR}"
 		)
-
-	if(ARG_BYPRODUCTS)
-		set(RM_BYPRODUCTS_COMMAND COMMAND "${CMAKE_COMMAND}" -E rm)
-		set(RM_BYPRODUCTS_PATHS "${ARG_BYPRODUCTS}")
-		list(TRANSFORM RM_BYPRODUCTS_PATHS PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
-	endif()
 
 	add_custom_command(
 		OUTPUT "Packaged/${NAME}"
-		BYPRODUCTS ${ARG_BYPRODUCTS}
 		DEPENDS BuildDirs
-		${ARG_COMMANDS}
-		${RM_BYPRODUCTS_COMMAND} ${RM_BYPRODUCTS_PATHS}
+		COMMAND "${CMAKE_COMMAND}" -E make_directory "${TMPDIR}"
+		${ARG_UNPARSED_ARGUMENTS}
+		COMMAND "${CMAKE_COMMAND}" -E rename
+			"${TMPDIR}/${NAME}"
+			"${CMAKE_CURRENT_BINARY_DIR}/Packaged/${NAME}"
+		COMMAND "${CMAKE_COMMAND}" -E rm -r -- "${TMPDIR}"
 		VERBATIM
 		)
 endfunction()
 
 add_data_file(ApplicationResources.gpf
-	BYPRODUCTS
-		Packaged/ApplicationResources.gpr
-		Packaged/ApplicationResources.gpa
-	COMMANDS
 	DEPENDS
 		MiniRez gpr2gpa FTagData MergeGPF "GliderProData/Glider PRO.r"
 		ApplicationResourcePatches/manifest.json DefaultTimestamp.timestamp
 	COMMAND MiniRez
 		"GliderProData/Glider PRO.r"
-		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpr"
+		"{TMPDIR}/ApplicationResources.gpr"
 	COMMAND gpr2gpa
-		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpr"
+		"{TMPDIR}/ApplicationResources.gpr"
 		DefaultTimestamp.timestamp
-		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpa"
+		"{TMPDIR}/ApplicationResources.gpa"
 		-patch ApplicationResourcePatches/manifest.json
 	COMMAND FTagData
 		DefaultTimestamp.timestamp
-		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpf"
+		"{TMPDIR}/ApplicationResources.gpf"
 		data ozm5 0 0 locked
 	COMMAND MergeGPF
-		"${CMAKE_CURRENT_BINARY_DIR}/Packaged/ApplicationResources.gpf"
+		"{TMPDIR}/ApplicationResources.gpf"
 	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 	)
 
 file(GLOB_RECURSE FONT_DEPS RELATIVE "${CMAKE_SOURCE_DIR}" CONFIGURE_DEPENDS Resources/Fonts/*)
 add_data_file(Fonts.gpf
-	BYPRODUCTS
-		Packaged/Fonts.gpr
-		Packaged/Fonts.gpa
-		Packaged/FontCacheCatalog.bin
-		Packaged/FontCacheManifest.json
-		Packaged/CachedFont0.bin
-		Packaged/CachedFont1.bin
-		Packaged/CachedFont2.bin
-		Packaged/CachedFont3.bin
-		Packaged/CachedFont4.bin
-		Packaged/CachedFont5.bin
-		Packaged/CachedFont6.bin
-		Packaged/CachedFont7.bin
-		Packaged/CachedFont8.bin
-		Packaged/CachedFont9.bin
-		Packaged/CachedFont10.bin
-		Packaged/CachedFont11.bin
-		Packaged/CachedFont12.bin
-		Packaged/CachedFont13.bin
-		Packaged/CachedFont14.bin
-	COMMANDS
 	DEPENDS GenerateFonts MiniRez gpr2gpa FTagData MergeGPF ${FONT_DEPS}
-	COMMAND GenerateFonts "${CMAKE_SOURCE_DIR}/Resources" Packaged
-	COMMAND MiniRez "${CMAKE_SOURCE_DIR}/Empty.r" Packaged/Fonts.gpr
+	COMMAND GenerateFonts "${CMAKE_SOURCE_DIR}/Resources" {TMPDIR}
+	COMMAND MiniRez "${CMAKE_SOURCE_DIR}/Empty.r" {TMPDIR}/Fonts.gpr
 	COMMAND gpr2gpa
-		Packaged/Fonts.gpr
+		{TMPDIR}/Fonts.gpr
 		"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
-		Packaged/Fonts.gpa
-		-patch Packaged/FontCacheManifest.json
+		{TMPDIR}/Fonts.gpa
+		-patch {TMPDIR}/FontCacheManifest.json
 	COMMAND FTagData
 		DefaultTimestamp.timestamp
-		Packaged/Fonts.gpf
+		{TMPDIR}/Fonts.gpf
 		data ozm5 0 0 locked
-	COMMAND MergeGPF Packaged/Fonts.gpf
+	COMMAND MergeGPF {TMPDIR}/Fonts.gpf
 	)
 
 # These files are committed to the repo and aren't currently useful on non-Windows systems anyway.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,22 @@ SET(EXECNAME "AerofoilX" CACHE STRING "Defines the exec name")
 
 message(${CMAKE_BINARY_DIR})
 
+# Use Release build type by default
+if("${CMAKE_BUILD_TYPE}" STREQUAL "")
+	set(CMAKE_BUILD_TYPE Release)
+	message("Build type unspecified, using Release")
+endif()
+
+# Enable LTO by default if supported
+if("${CMAKE_INTERPROCEDURAL_OPTIMIZATION}" STREQUAL "")
+	include(CheckIPOSupported)
+	check_ipo_supported(RESULT IPO_SUPPORTED)
+	if(IPO_SUPPORTED)
+		set(CMAKE_INTERPROCEDURAL_OPTIMIZATION On)
+		message("Compiler supports LTO, enabling automatically")
+	endif()
+endif()
+
 # FIXME: Clang treats this as an error by default; fixing the source rather
 # than downgrading the error to a warning would be a better solution.
 add_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,5 +321,19 @@ target_include_directories(hqx2bin PRIVATE
 	)
 target_link_libraries(hqx2bin PortabilityLayer)
 
+add_executable(hqx2gp
+	hqx2gp/hqx2gp.cpp
+	AerofoilPortable/GpAllocator_C.cpp
+	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+	)
+target_include_directories(hqx2gp PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	AerofoilPortable
+	WindowsUnicodeToolShim
+	)
+target_link_libraries(hqx2gp PortabilityLayer)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,4 +294,14 @@ if(CMAKE_HOST_UNIX)
 endif()
 
 
+add_executable(flattenmov flattenmov/flattenmov.cpp AerofoilPortable/GpAllocator_C.cpp)
+target_include_directories(flattenmov PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	AerofoilPortable
+	)
+target_link_libraries(flattenmov PortabilityLayer)
+
+
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,6 +519,46 @@ add_custom_command(
 	VERBATIM
 	)
 
+list(APPEND DATA_FILES Packaged/Fonts.gpf)
+add_custom_command(
+	OUTPUT
+		Packaged/Fonts.gpf
+	BYPRODUCTS
+		Packaged/Fonts.gpr
+		Packaged/Fonts.gpa
+		Packaged/FontCacheCatalog.bin
+		Packaged/FontCacheManifest.json
+		Packaged/CachedFont0.bin
+		Packaged/CachedFont1.bin
+		Packaged/CachedFont2.bin
+		Packaged/CachedFont3.bin
+		Packaged/CachedFont4.bin
+		Packaged/CachedFont5.bin
+		Packaged/CachedFont6.bin
+		Packaged/CachedFont7.bin
+		Packaged/CachedFont8.bin
+		Packaged/CachedFont9.bin
+		Packaged/CachedFont10.bin
+		Packaged/CachedFont11.bin
+		Packaged/CachedFont12.bin
+		Packaged/CachedFont13.bin
+		Packaged/CachedFont14.bin
+	DEPENDS GenerateFonts MiniRez gpr2gpa FTagData MergeGPF
+	COMMAND GenerateFonts "${CMAKE_SOURCE_DIR}/Resources" Packaged
+	COMMAND MiniRez "${CMAKE_SOURCE_DIR}/Empty.r" Packaged/Fonts.gpr
+	COMMAND gpr2gpa
+		Packaged/Fonts.gpr
+		"${CMAKE_SOURCE_DIR}/DefaultTimestamp.timestamp"
+		Packaged/Fonts.gpa
+		-patch Packaged/FontCacheManifest.json
+	COMMAND FTagData
+		DefaultTimestamp.timestamp
+		Packaged/Fonts.gpf
+		data ozm5 0 0 locked
+	COMMAND MergeGPF Packaged/Fonts.gpf
+	VERBATIM
+	)
+
 add_custom_target(Resources ALL
 	DEPENDS
 		${DATA_FILES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,6 +559,29 @@ add_custom_command(
 	VERBATIM
 	)
 
+# These files are committed to the repo and aren't currently useful on non-Windows systems anyway.
+#file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Aerofoil/ConvertedResources)
+#
+#set(CONVERTED_ICONS
+#	Aerofoil/ConvertedResources/Large128.ico
+#	Aerofoil/ConvertedResources/Large129.ico
+#	Aerofoil/ConvertedResources/Large130.ico
+#	Aerofoil/ConvertedResources/Large131.ico
+#	Aerofoil/ConvertedResources/Large132.ico
+#	Aerofoil/ConvertedResources/Large133.ico
+#	Aerofoil/ConvertedResources/Small128.ico
+#	Aerofoil/ConvertedResources/Small129.ico
+#	Aerofoil/ConvertedResources/Small130.ico
+#	Aerofoil/ConvertedResources/Small133.ico
+#	)
+#
+#add_custom_command(
+#	OUTPUT ${CONVERTED_ICONS}
+#	DEPENDS ConvertColorCursors Packaged/ApplicationResources.gpr
+#	COMMAND ConvertColorCursors
+#	)
+#add_custom_target(Icons DEPENDS ${CONVERTED_ICONS})
+
 add_custom_target(Resources ALL
 	DEPENDS
 		${DATA_FILES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,5 +406,40 @@ target_include_directories(HouseTool PRIVATE
 	)
 target_link_libraries(HouseTool PortabilityLayer MacRomanConversion)
 
+add_executable(unpacktool
+	unpacktool/ArchiveDescription.cpp
+	unpacktool/BWT.cpp
+	unpacktool/CompactProLZHDecompressor.cpp
+	unpacktool/CompactProLZHRLEDecompressor.cpp
+	unpacktool/CompactProParser.cpp
+	unpacktool/CompactProRLEDecompressor.cpp
+	unpacktool/CRC.cpp
+	unpacktool/CSInputBuffer.cpp
+	unpacktool/DecompressorProxyReader.cpp
+	unpacktool/LZSSDecompressor.cpp
+	unpacktool/LZW.cpp
+	unpacktool/LZWDecompressor.cpp
+	unpacktool/NullDecompressor.cpp
+	unpacktool/PrefixCode.cpp
+	unpacktool/RLE90Decompressor.cpp
+	unpacktool/StringCommon.cpp
+	unpacktool/StuffIt13Decompressor.cpp
+	unpacktool/StuffIt5Parser.cpp
+	unpacktool/StuffItArsenicDecompressor.cpp
+	unpacktool/StuffItCommon.cpp
+	unpacktool/StuffItHuffmanDecompressor.cpp
+	unpacktool/StuffItParser.cpp
+	unpacktool/unpacktool.cpp
+	WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+	)
+target_include_directories(unpacktool PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	MacRomanConversion
+	WindowsUnicodeToolShim
+	)
+target_link_libraries(unpacktool PortabilityLayer MacRomanConversion)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,5 +363,15 @@ add_executable(MakeTimestamp MakeTimestamp/MakeTimestamp.cpp)
 target_include_directories(MakeTimestamp PRIVATE PortabilityLayer)
 target_link_libraries(MakeTimestamp PortabilityLayer)
 
+add_executable(FTagData FTagData/FTagData.cpp WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp)
+target_include_directories(FTagData PRIVATE
+	Common
+	GpCommon
+	PortabilityLayer
+	AerofoilPortable
+	WindowsUnicodeToolShim
+	)
+target_link_libraries(FTagData PortabilityLayer)
+
 
 install (TARGETS ${EXECNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,18 +127,18 @@ add_library(PortabilityLayer STATIC
 	)
 
 target_include_directories(PortabilityLayer PRIVATE
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GpCommon>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/PortabilityLayer>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/zlib>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/rapidjson/include>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/MacRomanConversion>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/stb>
+	Common
+	GpCommon
+	PortabilityLayer
+	zlib
+	rapidjson/include
+	MacRomanConversion
+	stb
 	)
 
 target_compile_options(PortabilityLayer PRIVATE -Wno-multichar)
 
-target_link_libraries(PortabilityLayer zlib MacRomanConversion stb)
+target_link_libraries(PortabilityLayer PRIVATE zlib MacRomanConversion stb)
 
 
 add_library(GpShell STATIC
@@ -153,9 +153,9 @@ add_library(GpShell STATIC
 	)
 
 target_include_directories(GpShell PRIVATE
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GpCommon>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/PortabilityLayer>
+	Common
+	GpCommon
+	PortabilityLayer
 	)
 
 add_library(GpApp STATIC
@@ -233,16 +233,15 @@ add_library(GpApp STATIC
 target_compile_options(GpApp PRIVATE -Wno-multichar)
 
 target_include_directories(GpApp PRIVATE
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GpCommon>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/PortabilityLayer>
+	Common
+	GpCommon
+	PortabilityLayer
 	)
 
-target_link_libraries(GpApp PortabilityLayer)
+target_link_libraries(GpApp PRIVATE PortabilityLayer)
 
 if(CMAKE_HOST_UNIX)
-	set(EXEC_SOURCES )
-	list(APPEND EXEC_SOURCES
+	set(EXEC_SOURCES
 		AerofoilPortable/GpSystemServices_POSIX.cpp
 		AerofoilPortable/GpThreadEvent_Cpp11.cpp
 		AerofoilPortable/GpAllocator_C.cpp
@@ -260,21 +259,20 @@ if(CMAKE_HOST_UNIX)
 		AerofoilX/GpFileSystem_X.cpp
 		)
 
-	set(EXEC_LIBS )
-	list(APPEND EXEC_LIBS
+	set(EXEC_LIBS
 		${SDL2_LIBRARIES}
 		GpApp
 		GpShell
+		PortabilityLayer
 		)
 
-	set(EXEC_INC_DIRS )
-	list(APPEND EXEC_INC_DIRS
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common>
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GpCommon>
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GpShell>
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/AerofoilSDL>
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/AerofoilPortable>
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/PortabilityLayer>
+	set(EXEC_INC_DIRS
+		Common
+		GpCommon
+		GpShell
+		AerofoilSDL
+		AerofoilPortable
+		PortabilityLayer
 		${SDL2_INCLUDE_DIRS}
 		)
 	if(PLATFORM STREQUAL "MAC")
@@ -283,7 +281,7 @@ if(CMAKE_HOST_UNIX)
 			AerofoilMac/AerofoilMac/MacInit.mm
 			)
 		list(APPEND EXEC_INC_DIRS
-			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/AerofoilMac/AerofoilMac>
+			AerofoilMac/AerofoilMac
 			)
 		list(APPEND EXEC_LIBS
 			"-framework Cocoa"

--- a/ConvertResources.bat
+++ b/ConvertResources.bat
@@ -8,7 +8,7 @@ x64\Release\gpr2gpa.exe "Packaged\ApplicationResources.gpr" "DefaultTimestamp.ti
 x64\Release\FTagData.exe "DefaultTimestamp.timestamp" "Packaged\ApplicationResources.gpf" data ozm5 0 0 locked
 x64\Release\MergeGPF.exe "Packaged\ApplicationResources.gpf"
 
-x64\Release\GenerateFonts.exe
+x64\Release\GenerateFonts.exe Resources Packaged
 
 x64\Release\MiniRez.exe "Empty.r" Packaged\Fonts.gpr
 x64\Release\gpr2gpa.exe "Packaged\Fonts.gpr" "DefaultTimestamp.timestamp" "Packaged\Fonts.gpa" -patch "Packaged\FontCacheManifest.json"

--- a/FTagData/FTagData.cpp
+++ b/FTagData/FTagData.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string>
-#include <Windows.h>
+
 #include "MacFileInfo.h"
 #include "CFileStream.h"
 #include "CombinedTimestamp.h"

--- a/GpCommon/GpRenderedGlyphMetrics.h
+++ b/GpCommon/GpRenderedGlyphMetrics.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 struct GpRenderedGlyphMetrics

--- a/LINUX.txt
+++ b/LINUX.txt
@@ -1,18 +1,49 @@
-Linux support is IN ALPHA and may or may not work.  Only Cygwin has been
-tested so far.
+Linux support is IN ALPHA and may or may not work.
 
-You can attempt the following:
-- Install CMake (https://cmake.org/download/)
-- Install SDL 2.0.12 or higher, or build it from the included source
-- Run "cmake ." in the Aerofoil source directory
-- Run "make install" to build the AerofoilX program
-- Unzip the the Windows build
-- Copy the "Packaged" and "Resources" directories from the Windows build into
-  the "lib" folder above the "bin" folder that the AerofoilX program installed
-  to.  For example, if it installed to /usr/local/bin/, then the data files
-  should go in /usr/local/lib/aerofoil/
-- Run AerofoilX
+Use these basic steps to build and install Aerofoil:
+- Ensure dependencies are installed - all of these are likely available from
+  your distribution's package manager:
+    - CMake 3.10 or later (https://cmake.org/download/)
+    - SDL 2.0.12 or later (https://libsdl.org)
+    - FreeType 2.10.1 or later (https://freetype.org/download.html)
+- Change directory to the Aerofoil source root (the directory containing this file)
+- Run "cmake -B build" to create a CMake build tree under "build"
+- Run "cmake --build build" to build the AerofoilX program and its resources
+- Run "cmake --install build" to install everything under /usr/local
+- You can now run Aerofoil with the command "AerofoilX"
 
+You can also build just the AerofoilX executable and use the prebuilt resources
+from the Windows release:
+- Follow the steps above, ignoring the FreeType dependency and stopping after
+  running "cmake -B build"
+- Run "cmake --build build --target Executable" to build only the executable
+- Run "cmake --install build --component Executable" to install AerofoilX in
+  /usr/local/bin
+- Download the Windows build from
+  https://github.com/elasota/Aerofoil/releases/latest and unzip it
+- Create the directory /usr/local/lib/aerofoil and copy the "Packaged"
+  directory from the Windows build into it
+
+To install under a prefix other than /usr/local add
+"-DCMAKE_INSTALL_PREFIX=<prefix>" to "cmake -B build"
+
+Tools for converting Glider PRO houses are installed under
+/usr/local/lib/aerofoil/tools, see Documentation/userhouses.txt for
+instructions on how to use them.
+
+The main AerofoilX executable, its required resources and the conversion tools
+can be built and installed individually via these build targets and install
+components:
+- Executable
+- Resources
+- Tools
+
+For instance, you can use
+    cmake --build build --target Executable Resources
+to build only Aerofoil and its resources, and
+    cmake --install build --component Executable
+    cmake --install build --component Resources
+to install them.
 
 Please report any issues that you experience with this to the issue tracker on
 GitHub.

--- a/MiniRez/MiniRez.cpp
+++ b/MiniRez/MiniRez.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <stdio.h>
 #include <string>
 #include <vector>

--- a/WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
+++ b/WindowsUnicodeToolShim/UnixUnicodeToolShim.cpp
@@ -1,0 +1,99 @@
+#include "WindowsUnicodeToolShim.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <dirent.h>
+#include <sys/stat.h>
+
+// Linux and macOS (and probably other non-Windows systems in general) do not
+// have separate file system or command line APIs for different text encodings.
+// On these systems UTF-8 is commonly the system encoding and, if so, argv will
+// typically be UTF-8 encoded, though it is the calling process's responsibility
+// to ensure this, as argv is passed verbatim as a sequence of byte strings.
+//
+// Filesystems on Unix-like systems are typically encoding-unaware, in which
+// case the actual encoding used should match the system encoding, or else
+// manual intervention is required.
+//
+// On macOS, HFS+ and APFS filenames are encoded as UTF-16 and UTF-8
+// respectively, and the C filesystem API accepts UTF-8 strings. There are some
+// gotchas relating to Unicode normalization, where HFS+ enforces a specific
+// form of normalization at the filesystem layer but APFS does not, and using
+// the C API to access the filesystem may avoid automatic normalization that
+// higher-level macOS API functions may perform.
+//
+// In summary, text encoding is still a hairy problem on every computer system,
+// though on the major non-Windows systems, assuming UTF-8 encoding is
+// reasonable. For now, this header simply maps the WindowsUnicodeToolShim
+// functions to their regular C API counterparts.
+int toolMain(int argc, const char **argv);
+int main(int argc, const char **argv) { return toolMain(argc, argv); }
+
+FILE *fopen_utf8(const char *path, const char *options) { return fopen(path, options); }
+int fputs_utf8(const char *str, FILE *f) { return fputs(str, f); }
+int mkdir_utf8(const char *path) { return mkdir(path, 0777); }
+
+void TerminateDirectoryPath(std::string &path)
+{
+	const size_t len = path.length();
+
+	if (len == 0 || path[len - 1] != '/')
+		path.push_back('/');
+}
+
+void ScanDirectoryForExtension
+(
+	std::vector<std::string> &outPaths,
+	const char *path,
+	const char *ending,
+	bool recursive
+) {
+	DIR *dir = opendir(path);
+	if (!dir)
+	{
+		return;
+	}
+
+	size_t endingLen = strlen(ending);
+
+	dirent *ent;
+	while ((ent = readdir(dir)))
+	{
+		if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+			continue;
+		else if (recursive && ent->d_type == DT_DIR)
+		{
+			std::string tmpPath(path);
+			tmpPath.append("/");
+			tmpPath.append(ent->d_name);
+			ScanDirectoryForExtension(
+				outPaths,
+				tmpPath.c_str(),
+				ending,
+				recursive
+			);
+		}
+		else
+		{
+			size_t nameLen = strlen(ent->d_name);
+
+			if (endingLen <= nameLen && memcmp
+				(
+					ent->d_name + nameLen - endingLen,
+					ending,
+					endingLen
+				) == 0
+			) {
+				std::string tmpPath(path);
+				tmpPath.append("/");
+				tmpPath.append(ent->d_name);
+				outPaths.push_back(std::move(tmpPath));
+			}
+		}
+	}
+	closedir(dir);
+}

--- a/WindowsUnicodeToolShim/WindowsUnicodeToolShim.h
+++ b/WindowsUnicodeToolShim/WindowsUnicodeToolShim.h
@@ -8,6 +8,7 @@ int mkdir_utf8(const char *path);
 void TerminateDirectoryPath(std::string &path);
 void ScanDirectoryForExtension(std::vector<std::string>& outPaths, const char *path, const char *ending, bool recursive);
 
+#ifdef _WIN32
 struct DirectoryScanContext;
 struct DirectoryScanEntry
 {
@@ -17,3 +18,11 @@ struct DirectoryScanEntry
 DirectoryScanContext *opendir_utf8(const char *name);
 DirectoryScanEntry *readdir_utf8(DirectoryScanContext *dir);
 void closedir_utf8(DirectoryScanContext *context);
+
+#else
+
+inline int _fseeki64(FILE *stream, long offset, int whence) {
+	return fseek(stream, offset, whence);
+}
+inline long _ftelli64(FILE *stream) { return ftell(stream); };
+#endif

--- a/gpr2gpa/gpr2gpa.cpp
+++ b/gpr2gpa/gpr2gpa.cpp
@@ -1471,7 +1471,7 @@ bool DecompressSound(int compressionID, int channelCount, const void *sndData, s
 			}
 		}
 	}
-	else if (compressionID = AudioCompressionCodecID_SixToOne)
+	else if (compressionID == AudioCompressionCodecID_SixToOne)
 	{
 		if (channelCount != 1)
 		{

--- a/gpr2gpa/gpr2gpa.cpp
+++ b/gpr2gpa/gpr2gpa.cpp
@@ -31,9 +31,9 @@
 #include <stdio.h>
 #include <string>
 #include <sstream>
+#include <utility>
 #include <vector>
 #include <algorithm>
-#include "GpWindows.h"
 
 enum AudioCompressionCodecID
 {
@@ -2432,14 +2432,11 @@ int ConvertSingleFile(const char *resPath, const PortabilityLayer::CombinedTimes
 		const size_t numRefs = typeList.m_numRefs;
 
 		{
-			char subName[256];
-			sprintf_s(subName, "%s", resTag.m_id);
-
 			PlannedEntry entry;
-			entry.m_name = subName;
+			entry.m_name = resTag.m_id;
 			entry.m_isDirectory = true;
 
-			contents.push_back(entry);
+			contents.push_back(std::move(entry));
 		}
 
 		for (size_t rlIndex = 0; rlIndex < numRefs; rlIndex++)
@@ -2458,14 +2455,15 @@ int ConvertSingleFile(const char *resPath, const PortabilityLayer::CombinedTimes
 
 			if (typeList.m_resType == pictTypeID || typeList.m_resType == dateTypeID)
 			{
-				char resName[256];
-				sprintf_s(resName, "%s/%i.bmp", resTag.m_id, static_cast<int>(res.m_resID));
+				std::string resName = (
+					std::ostringstream() << resTag.m_id << '/' << res.m_resID << ".bmp"
+				).str();
 
-				if (ContainsName(reservedNames, resName))
+				if (ContainsName(reservedNames, resName.c_str()))
 					continue;
 
 				PlannedEntry entry;
-				entry.m_name = resName;
+				entry.m_name = std::move(resName);
 				entry.m_comment = resComment;
 
 				if (ImportPICT(entry.m_uncompressedContents, resData, resSize, dumpqtDir, res.m_resID))
@@ -2475,14 +2473,15 @@ int ConvertSingleFile(const char *resPath, const PortabilityLayer::CombinedTimes
 			}
 			else if (typeList.m_resType == sndTypeID)
 			{
-				char resName[256];
-				sprintf_s(resName, "%s/%i.wav", resTag.m_id, static_cast<int>(res.m_resID));
+				std::string resName = (
+					std::ostringstream() << resTag.m_id << '/' << res.m_resID << ".wav"
+				).str();
 
-				if (ContainsName(reservedNames, resName))
+				if (ContainsName(reservedNames, resName.c_str()))
 					continue;
 
 				PlannedEntry entry;
-				entry.m_name = resName;
+				entry.m_name = std::move(resName);
 				entry.m_comment = resComment;
 
 				if (ImportSound(entry.m_uncompressedContents, resData, resSize, res.m_resID))
@@ -2492,14 +2491,15 @@ int ConvertSingleFile(const char *resPath, const PortabilityLayer::CombinedTimes
 			}
 			else if (typeList.m_resType == indexStringTypeID)
 			{
-				char resName[256];
-				sprintf_s(resName, "%s/%i.txt", resTag.m_id, static_cast<int>(res.m_resID));
+				std::string resName = (
+					std::ostringstream() << resTag.m_id << '/' << res.m_resID << ".txt"
+				).str();
 
-				if (ContainsName(reservedNames, resName))
+				if (ContainsName(reservedNames, resName.c_str()))
 					continue;
 
 				PlannedEntry entry;
-				entry.m_name = resName;
+				entry.m_name = std::move(resName);
 				entry.m_comment = resComment;
 
 				if (ImportIndexedString(entry.m_uncompressedContents, resData, resSize))
@@ -2507,14 +2507,15 @@ int ConvertSingleFile(const char *resPath, const PortabilityLayer::CombinedTimes
 			}
 			else if (typeList.m_resType == ditlTypeID)
 			{
-				char resName[256];
-				sprintf_s(resName, "%s/%i.json", resTag.m_id, static_cast<int>(res.m_resID));
+				std::string resName = (
+					std::ostringstream() << resTag.m_id << '/' << res.m_resID << ".json"
+				).str();
 
-				if (ContainsName(reservedNames, resName))
+				if (ContainsName(reservedNames, resName.c_str()))
 					continue;
 
 				PlannedEntry entry;
-				entry.m_name = resName;
+				entry.m_name = std::move(resName);
 				entry.m_comment = resComment;
 
 				if (ImportDialogItemTemplate(entry.m_uncompressedContents, resData, resSize))
@@ -2529,15 +2530,16 @@ int ConvertSingleFile(const char *resPath, const PortabilityLayer::CombinedTimes
 					const IconTypeSpec &iconSpec = iconTypeSpecs[i];
 					if (typeList.m_resType == iconSpec.m_resTypeID)
 					{
-						char resName[256];
-						sprintf_s(resName, "%s/%i.bmp", resTag.m_id, static_cast<int>(res.m_resID));
+						std::string resName = (
+							std::ostringstream() << resTag.m_id << '/' << res.m_resID << ".bmp"
+						).str();
 
-						if (!ContainsName(reservedNames, resName))
+						if (!ContainsName(reservedNames, resName.c_str()))
 						{
 							isIcon = true;
 
 							PlannedEntry entry;
-							entry.m_name = resName;
+							entry.m_name = std::move(resName);
 							entry.m_comment = resComment;
 
 							if (ImportIcon(entry.m_uncompressedContents, resData, resSize, iconSpec.m_width, iconSpec.m_height, iconSpec.m_bpp))
@@ -2550,15 +2552,16 @@ int ConvertSingleFile(const char *resPath, const PortabilityLayer::CombinedTimes
 
 				if (!isIcon)
 				{
-					char resName[256];
-					sprintf_s(resName, "%s/%i.bin", resTag.m_id, static_cast<int>(res.m_resID));
+					std::string resName = (
+						std::ostringstream() << resTag.m_id << '/' << res.m_resID << ".bin"
+					).str();
 
-					if (ContainsName(reservedNames, resName))
+					if (ContainsName(reservedNames, resName.c_str()))
 						continue;
 
 					PlannedEntry entry;
 
-					entry.m_name = resName;
+					entry.m_name = std::move(resName);
 					entry.m_comment = resComment;
 					entry.m_uncompressedContents.resize(res.GetSize());
 

--- a/gpr2gpa/gpr2gpa.cpp
+++ b/gpr2gpa/gpr2gpa.cpp
@@ -98,6 +98,11 @@ void AppendFmt(std::vector<uint8_t> &array, const char *fmt, ...)
 	if (resultSize <= 0)
 		return;
 
+	// vsnprintf invalidates the va_list, so we need to
+	// reinit args so the next call doesn't print garbage.
+	va_end(args);
+	va_start(args, fmt);
+
 	size_t appendSize = static_cast<size_t>(resultSize);
 
 	if (SIZE_MAX == appendSize)

--- a/unpacktool/CompactProRLEDecompressor.h
+++ b/unpacktool/CompactProRLEDecompressor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "IDecompressor.h"
 
 class CompactProRLEDecompressor : public IDecompressor

--- a/unpacktool/IDecompressor.h
+++ b/unpacktool/IDecompressor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstddef>
 
 struct CSInputBuffer;
 

--- a/unpacktool/IFileReader.h
+++ b/unpacktool/IFileReader.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 struct IFileReader
 {

--- a/unpacktool/PrefixCode.cpp
+++ b/unpacktool/PrefixCode.cpp
@@ -1,3 +1,5 @@
+#include <climits>
+
 #include "PrefixCode.h"
 
 struct XADCodeTreeNode

--- a/unpacktool/RLE90Decompressor.h
+++ b/unpacktool/RLE90Decompressor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "IDecompressor.h"
 
 class RLE90Decompressor : public IDecompressor

--- a/unpacktool/unpacktool.cpp
+++ b/unpacktool/unpacktool.cpp
@@ -28,9 +28,6 @@
 
 #include <string.h>
 
-#include <Windows.h>
-#include <shellapi.h>
-
 #include <string>
 #include <vector>
 
@@ -387,7 +384,7 @@ int ExtractItem(int depth, const ArchiveItem &item, const std::string &dirPath, 
 	{
 		mkdir_utf8(path.c_str());
 
-		path.append("\\");
+		path.append("/");
 
 		int returnCode = RecursiveExtractFiles(depth + 1, item.m_children, path, pathParanoid, reader, ts);
 		if (returnCode)


### PR DESCRIPTION
Firstly, thanks for your work on this port, Eric! I was pleased to discover John Calhoun had released Glider PRO's source and just as pleased to discover you had spent the effort to bring this piece of Macintosh history to modern systems.

This PR ports the house and resource conversion tools to Linux and improves the CMake build system to produce (and optionally install) a fully functional build of Aerofoil without the need to import the converted resources from the Windows build.

I've tried to do this in as portable a way as possible, and building on Mac may work without further modification, though I am unable to test this myself.

I've kept Windows-specific code untouched as best I can, but please let me know if I've somehow broken something in the Windows build.

## Other notable changes
- **Enable Git line ending normalization for most text files**
  Some files have CRLF endings, some files have LF endings, some files have mixed line endings. Letting Git normalize line endings internally will avoid whitespace-only merge conflicts in the future.
  - **This will cause merge conflicts by default** when merging branches based before this change. I'll keep my branch rebased against `master`, but if someone runs into conflicts, add `-X renormalize` to `git merge` or `git rebase` to resolve the issue automatically.
- **Fix double-use of `va_list` in `gpr2gpa.cpp::AppendFmt()`**
  This one is actually a pretty major bug that the Windows version doesn't exhibit by sheer luck. On Linux, this causes the second call to `vsnprintf()` to print garbage, resulting in invalid JSON.
- **Fix `=` instead of `==` in `gpr2gpa.cpp::DecompressSound()`**
  This typo means the following "unknown format" else-branch can never be hit, but I don't think it causes issues in practice when converting Glider PRO's resources. Still, no reason not to fix this.
- **Use `/` as path separator in a couple of the conversion tools**
  Windows should have no problem with this whatsoever, but I'm making a note of this as I haven't tested Windows. If this does somehow break something, it will likely break it loudly, at least.
- **Avoid Clang `c++11-narrowing` error**
  This is a warning by default in GCC, but a hard error in Clang, so I've added `-Wno-error=c++11-narrowing` when compiling with Clang. At some point, someone could fix the cause of this warning as a more permanent fix. I might submit another PR squashing some warnings in the future.
- **Update `LINUX.txt` with new and more detailed instructions**

## Related issues
- #2
  Probably resolved, as building on Linux is pretty painless now and Aerofoil seems to run fine, though I haven't rigorously tested absolutely everything.
- #8 and #14
  Resolved if Mac can successfully build the tools in this branch.